### PR TITLE
Added missing include of <numeric> for std::accumulate

### DIFF
--- a/aquila/transform/Mfcc.cpp
+++ b/aquila/transform/Mfcc.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <numeric>
 #include <opencv2/core/core.hpp>
 
 namespace Aquila


### PR DESCRIPTION
On gcc6.2 std::accumulate is not found due to a missing include. This commit fixes this.